### PR TITLE
feat(api): reservations API 연동 및 DTO 매핑 적용

### DIFF
--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -1,0 +1,66 @@
+// src/api/http.ts
+// fetch 기반의 최소 공용 HTTP 유틸
+
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+export interface HttpRequestOptions {
+  method?: HttpMethod;
+  headers?: Record<string, string>;
+  query?: Record<string, string | number | boolean | undefined | null>;
+  body?: unknown;
+  signal?: AbortSignal;
+}
+
+const buildQueryString = (query: HttpRequestOptions['query']): string => {
+  if (!query) return '';
+  const usp = new URLSearchParams();
+  Object.entries(query).forEach(([k, v]) => {
+    if (v === undefined || v === null) return;
+    usp.set(k, String(v));
+  });
+  const qs = usp.toString();
+  return qs ? `?${qs}` : '';
+};
+
+const getApiBaseUrl = (): string => {
+  // 기본은 same-origin(`/api/...`) 사용. 필요시 VITE_API_BASE_URL 로 오버라이드.
+  const envBase = (import.meta as unknown as { env?: Record<string, string> }).env?.VITE_API_BASE_URL;
+  return envBase ?? '';
+};
+
+export class HttpError extends Error {
+  status: number;
+  bodyText?: string;
+
+  constructor(message: string, status: number, bodyText?: string) {
+    super(message);
+    this.name = 'HttpError';
+    this.status = status;
+    this.bodyText = bodyText;
+  }
+}
+
+export async function requestJson<T>(path: string, options: HttpRequestOptions = {}): Promise<T> {
+  const baseUrl = getApiBaseUrl();
+  const url = `${baseUrl}${path}${buildQueryString(options.query)}`;
+
+  const res = await fetch(url, {
+    method: options.method ?? 'GET',
+    headers: {
+      Accept: 'application/json',
+      ...(options.body ? { 'Content-Type': 'application/json' } : {}),
+      ...(options.headers ?? {}),
+    },
+    body: options.body ? JSON.stringify(options.body) : undefined,
+    signal: options.signal,
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => undefined);
+    throw new HttpError(`HTTP ${res.status} ${res.statusText}`, res.status, text);
+  }
+
+  return (await res.json()) as T;
+}
+
+

--- a/src/api/reservations.ts
+++ b/src/api/reservations.ts
@@ -1,0 +1,253 @@
+// src/api/reservations.ts
+// docs/API_명세서.md 기반: "오늘 발송 예약" 및 "예약 상세" API
+
+import dayjs from 'dayjs';
+import type { ChipStatus } from '../common/ui/Chip';
+import type { TableRowData } from './types';
+import { requestJson } from './http';
+
+/**
+ * 1) 서버 응답 타입 (명세서의 필드명을 그대로 반영)
+ * - 나중에 실제 JSON 예시로 키가 바뀌면 "여기"만 수정하면 됨.
+ */
+export type ReservationStatusServer = 'READY' | 'PENDING' | 'COMPLETED' | 'FAILED' | 'CANCELED';
+export type ChannelTypeServer = 'PUSH' | 'ALIMTALK' | string;
+
+export interface TodayReservationRowServer {
+  id: number;
+  personaId: number;
+  personaName: string;
+  scheduledAt: string; // "2025-12-30T09:00:00"
+  channelType: ChannelTypeServer;
+  status: ReservationStatusServer;
+  targetCount: number;
+  itemId: number;
+  itemKey: string;
+  itemName: string;
+  messageId: number;
+  messageTitle: string;
+  messageDescription: string;
+}
+
+export interface SpringPageServer<T> {
+  content: T[];
+  totalElements: number;
+  totalPages: number;
+  number: number;
+  size: number;
+  first: boolean;
+  last: boolean;
+  pageable?: unknown;
+  sort?: unknown;
+}
+
+export interface ReservationDetailServer {
+  id: number;
+  personaId: number;
+  personaName: string;
+  scheduledAt: string;
+  channelType: ChannelTypeServer;
+  status: ReservationStatusServer;
+  targetCount: number;
+  item: {
+    id: number;
+    itemKey: string;
+    name: string;
+  };
+  message: {
+    id: number;
+    title: string;
+    description: string;
+  };
+  recommendReason?: string;
+}
+
+/**
+ * 2) 프론트 DTO (추천 필드명)
+ * - UI가 다루기 쉬운 구조로 정규화/정리한 형태
+ * - "DTO 필드명"을 나중에 바꾸고 싶으면 여기/매퍼만 고치면 됨.
+ */
+export type ReservationStatusDto = ReservationStatusServer;
+export type ChannelTypeDto = ChannelTypeServer;
+
+export interface ReservationMessageDto {
+  messageId: number;
+  title: string;
+  description: string;
+}
+
+export interface ReservationItemDto {
+  itemId: number;
+  itemKey: string;
+  name: string;
+}
+
+export interface ReservationSummaryDto {
+  reservationId: number;
+  personaId: number;
+  personaName: string;
+  scheduledAt: string;
+  channelType: ChannelTypeDto;
+  status: ReservationStatusDto;
+  targetCount: number;
+  item: ReservationItemDto;
+  message: ReservationMessageDto;
+}
+
+export interface ReservationDetailDto extends ReservationSummaryDto {
+  recommendReason?: string;
+}
+
+export interface PageDto<T> {
+  items: T[];
+  page: number;
+  size: number;
+  totalItems: number;
+  totalPages: number;
+  isFirst: boolean;
+  isLast: boolean;
+}
+
+const toPageDto = <T>(p: SpringPageServer<T>): PageDto<T> => ({
+  items: p.content ?? [],
+  page: p.number ?? 0,
+  size: p.size ?? 10,
+  totalItems: p.totalElements ?? 0,
+  totalPages: p.totalPages ?? 0,
+  isFirst: Boolean(p.first),
+  isLast: Boolean(p.last),
+});
+
+const mapChannelLabel = (channelType: ChannelTypeDto): string => {
+  if (channelType === 'PUSH') return '푸시';
+  if (channelType === 'ALIMTALK') return '카카오톡 알림톡';
+  return String(channelType);
+};
+
+const mapStatusToChipStatus = (status: ReservationStatusDto): ChipStatus => {
+  switch (status) {
+    case 'READY':
+      return 'info'; // 발송 대기
+    case 'PENDING':
+      return 'paused'; // 진행/대기(임시로 일시정지 UI 컬러 사용)
+    case 'COMPLETED':
+      return 'success'; // 발송 완료
+    case 'FAILED':
+      return 'warning'; // 실패(확인 필요)
+    case 'CANCELED':
+      return 'error'; // 발송 취소
+    default:
+      return 'default';
+  }
+};
+
+const buildProductUrl = (itemId?: number): string | undefined => {
+  if (!itemId || !Number.isFinite(itemId)) return undefined;
+  // 기존 mock과 동일한 패턴
+  return `https://www.amoremall.com/kr/ko/product/detail?pid=${itemId}`;
+};
+
+export const mapTodayRowServerToDto = (row: TodayReservationRowServer): ReservationSummaryDto => ({
+  reservationId: row.id,
+  personaId: row.personaId,
+  personaName: row.personaName,
+  scheduledAt: row.scheduledAt,
+  channelType: row.channelType,
+  status: row.status,
+  targetCount: row.targetCount,
+  item: {
+    itemId: row.itemId,
+    itemKey: row.itemKey,
+    name: row.itemName,
+  },
+  message: {
+    messageId: row.messageId,
+    title: row.messageTitle,
+    description: row.messageDescription,
+  },
+});
+
+export const mapDetailServerToDto = (d: ReservationDetailServer): ReservationDetailDto => ({
+  reservationId: d.id,
+  personaId: d.personaId,
+  personaName: d.personaName,
+  scheduledAt: d.scheduledAt,
+  channelType: d.channelType,
+  status: d.status,
+  targetCount: d.targetCount,
+  item: {
+    itemId: d.item.id,
+    itemKey: d.item.itemKey,
+    name: d.item.name,
+  },
+  message: {
+    messageId: d.message.id,
+    title: d.message.title,
+    description: d.message.description,
+  },
+  recommendReason: d.recommendReason,
+});
+
+/**
+ * 3) DTO -> 화면(UI) 모델(TableRowData) 매핑
+ * - 지금 UI는 TableRowData를 중심으로 구성되어 있어 최소 변경으로 연결
+ */
+export const mapReservationDtoToTableRow = (dto: ReservationSummaryDto | ReservationDetailDto): TableRowData => {
+  const dt = dayjs(dto.scheduledAt);
+  const date = dt.isValid() ? dt.format('YYYY-MM-DD') : '';
+  const time = dt.isValid() ? dt.format('HH:mm') : '';
+
+  return {
+    id: dto.reservationId,
+    persona: dto.personaName,
+    personaId: String(dto.personaId),
+    date,
+    time,
+    product: dto.item?.name ?? '-',
+    productUrl: buildProductUrl(dto.item?.itemId),
+    title: dto.message?.title ?? '',
+    description: dto.message?.description ?? '',
+    status: mapStatusToChipStatus(dto.status),
+    channel: mapChannelLabel(dto.channelType),
+    recipientCount: dto.targetCount,
+    recommendedReason: 'recommendReason' in dto ? dto.recommendReason : undefined,
+  };
+};
+
+/**
+ * 4) API 함수
+ */
+export interface GetTodayReservationsParams {
+  date?: string; // YYYY-MM-DD
+  status?: ReservationStatusServer;
+  productSearch?: string;
+  page?: number;
+  size?: number;
+  sort?: string; // 예: scheduledAt,asc
+}
+
+export async function getTodayReservations(params: GetTodayReservationsParams = {}): Promise<PageDto<ReservationSummaryDto>> {
+  const res = await requestJson<SpringPageServer<TodayReservationRowServer>>('/api/reservations/today', {
+    query: {
+      date: params.date,
+      status: params.status,
+      productSearch: params.productSearch,
+      page: params.page ?? 0,
+      size: params.size ?? 50,
+      sort: params.sort ?? 'scheduledAt,asc',
+    },
+  });
+
+  const page = toPageDto(res);
+  return {
+    ...page,
+    items: page.items.map(mapTodayRowServerToDto),
+  };
+}
+
+export async function getReservationDetail(reservationId: number): Promise<ReservationDetailDto> {
+  const res = await requestJson<ReservationDetailServer>(`/api/reservations/${reservationId}`);
+  return mapDetailServerToDto(res);
+}
+
+


### PR DESCRIPTION
### 변경사항 리스트(파일 단위)
**1. src/api/http.ts: fetch 기반 공용 requestJson 추가(에러 처리 포함)**

**2. src/api/reservations.ts: 명세 기반**
- 서버 응답 타입 정의
- 프론트 DTO(추천 필드명) 정의
- 서버→DTO / DTO→UI 모델 매퍼
- getTodayReservations, getReservationDetail API 함수

**3. src/App.tsx:**
- 오늘 탭 데이터 source를 mock → /api/reservations/today로 교체
- Drawer 오픈 시 /api/reservations/{id}로 상세 보강