### PR TITLE
[feature/aketer-14] 테이블 필터/상세 Drawer UX 개선

### DIFF
--- a/src/common/ui/ConfirmModal.tsx
+++ b/src/common/ui/ConfirmModal.tsx
@@ -1,0 +1,72 @@
+import type { ReactNode } from 'react';
+import { Dialog, DialogActions, DialogContent, DialogTitle, Stack, Typography, Button } from '@mui/material';
+import { amoreTokens } from '../../styles/theme';
+
+export type ConfirmModalTone = 'primary' | 'danger';
+
+export interface ConfirmModalProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  tone?: ConfirmModalTone;
+  confirmText?: string;
+  cancelText?: string;
+  onConfirm: () => void;
+  confirmDisabled?: boolean;
+  description?: ReactNode;
+  content?: ReactNode;
+}
+
+/**
+ * 공통 ConfirmModal
+ * - 확인/취소 2버튼 패턴을 통일한다.
+ * - 복잡한 multi-step flow(예: 시간 변경 2단계)는 범위 밖이다.
+ */
+export const ConfirmModal = ({
+  open,
+  onClose,
+  title,
+  tone = 'primary',
+  confirmText = '확인',
+  cancelText = '닫기',
+  onConfirm,
+  confirmDisabled = false,
+  description,
+  content,
+}: ConfirmModalProps) => {
+  const confirmColor =
+    tone === 'danger' ? amoreTokens.colors.status.red : amoreTokens.colors.brand.pacificBlue;
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle sx={{ fontWeight: 900, color: tone === 'danger' ? confirmColor : undefined }}>
+        {title}
+      </DialogTitle>
+      <DialogContent dividers>
+        <Stack spacing={1.5}>
+          {description ? (
+            <Typography variant="body2" sx={{ color: amoreTokens.colors.gray[700] }}>
+              {description}
+            </Typography>
+          ) : null}
+          {content}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button variant="outlined" onClick={onClose}>
+          {cancelText}
+        </Button>
+        <Button
+          variant="contained"
+          onClick={onConfirm}
+          disabled={confirmDisabled}
+          sx={{ bgcolor: confirmColor }}
+        >
+          {confirmText}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+

--- a/src/common/ui/Popover.tsx
+++ b/src/common/ui/Popover.tsx
@@ -1,0 +1,59 @@
+import type { ReactNode } from 'react';
+import { Popover as MuiPopover } from '@mui/material';
+import type { PopoverOrigin } from '@mui/material/Popover';
+import type { SxProps, Theme } from '@mui/material/styles';
+import { amoreTokens } from '../../styles/theme';
+
+export interface PopoverProps {
+  id?: string;
+  open: boolean;
+  anchorEl: HTMLElement | null;
+  onClose: () => void;
+  children: ReactNode;
+  anchorOrigin?: PopoverOrigin;
+  transformOrigin?: PopoverOrigin;
+  paperSx?: SxProps<Theme>;
+}
+
+/**
+ * 공통 Popover 래퍼
+ * - 기본 borderRadius 등 공통 스타일 제공
+ * - open/anchorEl/onClose 제어는 사용처에서 유지(회귀 최소화)
+ */
+export const Popover = ({
+  id,
+  open,
+  anchorEl,
+  onClose,
+  children,
+  anchorOrigin = { vertical: 'bottom', horizontal: 'left' },
+  transformOrigin = { vertical: 'top', horizontal: 'left' },
+  paperSx,
+}: PopoverProps) => {
+  return (
+    <MuiPopover
+      id={id}
+      open={open}
+      anchorEl={anchorEl}
+      onClose={onClose}
+      anchorOrigin={anchorOrigin}
+      transformOrigin={transformOrigin}
+      slotProps={{
+        paper: {
+          sx: {
+            borderRadius: amoreTokens.radius.base,
+            width: { xs: '16rem', sm: '18rem' },
+            '& .MuiButton-root': {
+              minHeight: 30,
+              padding: '0.25rem 0.625rem',
+              fontSize: '0.8125rem',
+            },
+            ...paperSx,
+          },
+        },
+      }}
+    >
+      {children}
+    </MuiPopover>
+  );
+};

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -121,5 +121,16 @@ export const amoreTheme = createTheme({
         },
       },
     },
+    MuiChip: {
+      styleOverrides: {
+        root: {
+          borderRadius: amoreTokens.radius.base,
+        },
+        outlined: {
+          // Chip variant="outlined" 기본 보더 컬러를 전역으로 통일
+          borderColor: amoreTokens.colors.gray[300],
+        },
+      },
+    },
   },
 });


### PR DESCRIPTION
### 📝 작업 내용
**DataTable**
```
페르소나 필터를 멀티 선택(Autocomplete + Checkbox) 로 개선
채널 필터(Select) 추가 및 채널을 Chip 배지로 표시
필터 Popover를 공통 Popover로 래핑해 스타일/버튼 사이징 통일
페르소나/상품 액션 hover 안내(Tooltip) 추가
```
**DetailDrawer**
```
헤더에 예약 ID/상태 요약(트렌드: 성공·실패 카운트) 표시
실패 리스트에서 재처리 가능/불가 UX(툴팁/비활성/hover) 강화
취소/재처리 확인 UI를 공통 ConfirmModal로 통일
```
**PersonaDrawer**
```
발송 히스토리에서 항목 클릭 시 상세 Drawer 바로 열기로 접근성 개선
```
**theme**
```
MuiChip 전역 스타일 오버라이드로 라운딩/outlined border 컬러 통일
```

### ⚙️ 변경 사항 확인
```
RDB 변경 여부: no
라이브러리 추가 여부: no
```
